### PR TITLE
add support for album download

### DIFF
--- a/pybaiduphoto/API.py
+++ b/pybaiduphoto/API.py
@@ -105,26 +105,82 @@ class Album():
             'list': [{
                 'album_id': "xxxx",
                 'path': "xxx.jpg"
+                'tid':"xxx"
                 }],
             'has_more': 1,
             'errno': 0,
             }
     '''
     def get_pictures(self, cursor='',need_amount=1,limit=100,password='')->dict:
+        params = {
+                'album_id': self.info['album_id'],
+                'need_amount':need_amount,
+                'limit':limit,
+                }
+
+        if cursor != '':
+            params['cursor'] = cursor
+        if password != '':
+            params['passwd'] = password
+
         pageInfo = self.req.postReqJson(
                 url = 'https://photo.baidu.com/youai/album/v1/listfile',
-                cursor= cursor,
-                album_id= self.info['album_id'],
-                need_amount=need_amount,
-                limit=limit,
-                passwd=password
+                data=params
                 )
-
+        '''
+        URL: https://photo.baidu.com/youai/album/v1/copyfile?clienttype=70
+        Method: POST
+        Params: {
+                'album_id': '',
+                'uk': '',
+                'tid': '',
+                'list': [
+                    "fsid":""
+                    ]
+                }
+        res: {
+                'list': [
+                    {
+                        "from_fsid": 140373302001753,
+                        "fsid": 522136190789429,
+                        "path": ".jpg",
+                        "shoot_time": 1619209924,
+                    }
+                    ],
+                "errno": 0,
+                request_id: 311534367474440450
+                }
+        '''
+        '''
+        URL: https://photo.baidu.com/youai/file/v2/download?clienttype=70
+        Method: GET
+        Params: {
+                fsid=522136190789429
+                }
+        '''
         return {
                 'items': [OnlineIterm(i,self.req) for i in pageInfo['list']],
                 'has_more': pageInfo['has_more'],
                 'cursor': pageInfo['cursor'],
         }
+    def __reget_fsid__(self, pic_info)->dict:
+        params = {
+                'album_id': self.info['album_id'],
+                'uk': self.info['cover_info']['uk'],
+                'tid': pic_info['tid'],
+                'list': "[{\"fsid\":%s}]"%(pic_info['fsid']),
+                }
+        res = self.req.postReqJson(url='https://photo.baidu.com/youai/album/v1/copyfile?clienttype=70&bdstoken=80bf8beaf28275d9bf8c1dc9c4d6786b',
+                data=params)
+        if res['errno'] != 0:
+            return pic_info
+        print(res)
+        pic_info['fsid'] = res['list'][0]['fsid']
+        return pic_info
+
+    def download_pic(self,item: OnlineIterm, dirpath: str):
+        item.info = self.__reget_fsid__(item.info)
+        return item.download(dirpath)
 
     def append(self,itemObjs):
         if type(itemObjs) is not list:

--- a/pybaiduphoto/API.py
+++ b/pybaiduphoto/API.py
@@ -5,8 +5,7 @@ import logging
 
 from .Requests import Requests
 
-
-
+from typing import List, TypedDict
 
 # def get_md5_by_binString(binString):
 #     return hashlib.md5(binString).hexdigest()
@@ -85,6 +84,10 @@ class OnlineIterm():
         return str(self.info['fsid'])
 
 
+class AlbumInfo(TypedDict):
+    items: List[OnlineIterm]
+    has_more: bool
+    cursor:str
 
 class Album():
 
@@ -111,7 +114,7 @@ class Album():
             'errno': 0,
             }
     '''
-    def get_pictures(self, cursor='',need_amount=1,limit=100,password='')->dict:
+    def get_pictures(self,cursor='',need_amount=1,limit=100,password='')->AlbumInfo:
         params = {
                 'album_id': self.info['album_id'],
                 'need_amount':need_amount,
@@ -163,7 +166,7 @@ class Album():
                 'has_more': pageInfo['has_more'],
                 'cursor': pageInfo['cursor'],
         }
-    def __reget_fsid__(self, pic_info)->dict:
+    def __reget_fsid__(self, pic_info)->AlbumInfo:
         params = {
                 'album_id': self.info['album_id'],
                 'uk': self.info['cover_info']['uk'],

--- a/pybaiduphoto/API.py
+++ b/pybaiduphoto/API.py
@@ -90,7 +90,41 @@ class Album():
 
     def __init__(self,info,req):
         self.info = info
-        self.req = req
+        self.req:Requests = req
+
+    '''
+    API: https://photo.baidu.com/youai/album/v1/listfile
+    Method: POST
+    Param: {
+            cursor=,
+            album_id=12345,
+            need_amount=1,
+            limit=100&passwd=
+            }
+    {
+            'list': [{
+                'album_id': "xxxx",
+                'path': "xxx.jpg"
+                }],
+            'has_more': 1,
+            'errno': 0,
+            }
+    '''
+    def get_pictures(self, cursor='',need_amount=1,limit=100,password='')->dict:
+        pageInfo = self.req.postReqJson(
+                url = 'https://photo.baidu.com/youai/album/v1/listfile',
+                cursor= cursor,
+                album_id= self.info['album_id'],
+                need_amount=need_amount,
+                limit=limit,
+                passwd=password
+                )
+
+        return {
+                'items': [OnlineIterm(i,self.req) for i in pageInfo['list']],
+                'has_more': pageInfo['has_more'],
+                'cursor': pageInfo['cursor'],
+        }
 
     def append(self,itemObjs):
         if type(itemObjs) is not list:

--- a/pybaiduphoto/API.py
+++ b/pybaiduphoto/API.py
@@ -170,11 +170,11 @@ class Album():
                 'tid': pic_info['tid'],
                 'list': "[{\"fsid\":%s}]"%(pic_info['fsid']),
                 }
-        res = self.req.postReqJson(url='https://photo.baidu.com/youai/album/v1/copyfile?clienttype=70&bdstoken=80bf8beaf28275d9bf8c1dc9c4d6786b',
+        res = self.req.postReqJson(url='https://photo.baidu.com/youai/album/v1/copyfile',
                 data=params)
         if res['errno'] != 0:
             return pic_info
-        print(res)
+        logging.debug(res)
         pic_info['fsid'] = res['list'][0]['fsid']
         return pic_info
 


### PR DESCRIPTION
- feat(API): add Album::get_pictures method
- fix(API): fix fsid error about album

add some functions for download pictures by album:

```python3
api = API(cookies=cookies)

alist = api.getAlbumList()

# download the first picture of first album
for album in alist['items']:
    pics = album.get_pictures()
    print(album.info['title'])
    album.download_pic(pics['items'][0],'/home/tea/1')
    exit(0)
```
