### PR TITLE
统一 album 和 get_SinglePage 的下载方式

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
-
 *.ipynb
-
 test\.py
-
 \.DS_Store
+*.pyc

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.2.0
+    hooks:
+    -   id: check-yaml
+    -   id: end-of-file-fixer
+    -   id: fix-byte-order-marker
+    -   id: requirements-txt-fixer
+    -   id: trailing-whitespace
+-   repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+    -   id: black

--- a/pybaiduphoto/API.py
+++ b/pybaiduphoto/API.py
@@ -95,74 +95,21 @@ class Album:
         self.info = info
         self.req: Requests = req
 
-    """
-    API: https://photo.baidu.com/youai/album/v1/listfile
-    Method: POST
-    Param: {
-            cursor=,
-            album_id=12345,
-            need_amount=1,
-            limit=100&passwd=
-            }
-    {
-            'list': [{
-                'album_id': "xxxx",
-                'path': "xxx.jpg"
-                'tid':"xxx"
-                }],
-            'has_more': 1,
-            'errno': 0,
-            }
-    """
-
     def get_pictures(
         self, cursor="", need_amount=1, limit=100, password=""
     ) -> AlbumInfo:
         params = {
+            "cursor": cursor,
             "album_id": self.info["album_id"],
             "need_amount": need_amount,
             "limit": limit,
+            "passwd": password,
         }
-
-        if cursor != "":
-            params["cursor"] = cursor
-        if password != "":
-            params["passwd"] = password
 
         pageInfo = self.req.postReqJson(
             url="https://photo.baidu.com/youai/album/v1/listfile", data=params
         )
-        """
-        URL: https://photo.baidu.com/youai/album/v1/copyfile?clienttype=70
-        Method: POST
-        Params: {
-                'album_id': '',
-                'uk': '',
-                'tid': '',
-                'list': [
-                    "fsid":""
-                    ]
-                }
-        res: {
-                'list': [
-                    {
-                        "from_fsid": 140373302001753,
-                        "fsid": 522136190789429,
-                        "path": ".jpg",
-                        "shoot_time": 1619209924,
-                    }
-                    ],
-                "errno": 0,
-                request_id: 311534367474440450
-                }
-        """
-        """
-        URL: https://photo.baidu.com/youai/file/v2/download?clienttype=70
-        Method: GET
-        Params: {
-                fsid=522136190789429
-                }
-        """
+
         return {
             "items": [OnlineIterm(i, self.req) for i in pageInfo["list"]],
             "has_more": pageInfo["has_more"],
@@ -179,10 +126,14 @@ class Album:
         res = self.req.postReqJson(
             url="https://photo.baidu.com/youai/album/v1/copyfile", data=params
         )
+
         if res["errno"] != 0:
             return pic_info
+
         logging.debug(res)
+
         pic_info["fsid"] = res["list"][0]["fsid"]
+
         return pic_info
 
     def download_pic(self, item: OnlineIterm, dirpath: str):

--- a/pybaiduphoto/API.py
+++ b/pybaiduphoto/API.py
@@ -24,78 +24,78 @@ from typing import List, TypedDict
 #         'md5':get_md5_by_LocalFile(filePath),
 #     }
 
+
 def get_file_fullContent(filePath):
-    with open(filePath,'rb') as f:
+    with open(filePath, "rb") as f:
         binString = f.read()
         md5 = hashlib.md5(binString).hexdigest()
     return {
-        'fileName' : os.path.basename(filePath),
-        'localFilePath' : filePath,
-        'size' : os.path.getsize(filePath),
-        'ctime': int(os.path.getctime(filePath)),
-        'mtime': int(os.path.getmtime(filePath)),
-        'md5':md5,
-        'bin':binString,
+        "fileName": os.path.basename(filePath),
+        "localFilePath": filePath,
+        "size": os.path.getsize(filePath),
+        "ctime": int(os.path.getctime(filePath)),
+        "mtime": int(os.path.getmtime(filePath)),
+        "md5": md5,
+        "bin": binString,
     }
 
 
-
-
-
-class OnlineIterm():
-
-    def __init__(self,info,req):
+class OnlineIterm:
+    def __init__(self, info, req):
         self.info = info
         self.req = req
 
-    def download(self,DirPath,isCheckMd5=True):
+    def download(self, DirPath, isCheckMd5=True):
         r = self.req.getReqJson(
-            url= 'https://photo.baidu.com/youai/file/v2/download',
+            url="https://photo.baidu.com/youai/file/v2/download",
             params={
-                'clienttype': '70',
-    #             'bdstoken': 'ba0b17594add5...?',
-                'fsid':self.info['fsid'],
+                "clienttype": "70",
+                #             'bdstoken': 'ba0b17594add5...?',
+                "fsid": self.info["fsid"],
             },
         )
-        fileName = self.info['path'].split('/')[-1]
-        filePath = os.path.join(DirPath,fileName)
-        req = self.req.get(r['dlink'])
-        with open(filePath,'wb') as f:
+        fileName = self.info["path"].split("/")[-1]
+        filePath = os.path.join(DirPath, fileName)
+        req = self.req.get(r["dlink"])
+        with open(filePath, "wb") as f:
             f.write(req.content)
-        os.utime(filePath,(self.info.get('mtime',None),self.info.get('ctime',None)),) # reset ctime,mtime
+        os.utime(
+            filePath,
+            (self.info.get("mtime", None), self.info.get("ctime", None)),
+        )  # reset ctime,mtime
         if isCheckMd5:
             localMd5 = hashlib.md5(req.content).hexdigest()
-            if self.info['md5'] != localMd5:
-                info.error('md5 check error, file=[{}]'.format(filePath))
+            if self.info["md5"] != localMd5:
+                info.error("md5 check error, file=[{}]".format(filePath))
 
-    def delete(self,fdis_list=None):
-        url = 'https://photo.baidu.com/youai/file/v1/delete'
+    def delete(self, fdis_list=None):
+        url = "https://photo.baidu.com/youai/file/v1/delete"
         if fdis_list is None:
             fdis_list = [self.get_fsid()]
         params = {
-            'clienttype' : '70',
-            'fsid_list' : '[{}]'.format( ",".join(fdis_list) ),
+            "clienttype": "70",
+            "fsid_list": "[{}]".format(",".join(fdis_list)),
         }
-        logging.debug('item-delete:get params=[{}]'.format(params))
-        r = self.req.getReqJson(url,params=params)
+        logging.debug("item-delete:get params=[{}]".format(params))
+        r = self.req.getReqJson(url, params=params)
         return r
 
     def get_fsid(self):
-        return str(self.info['fsid'])
+        return str(self.info["fsid"])
 
 
 class AlbumInfo(TypedDict):
     items: List[OnlineIterm]
     has_more: bool
-    cursor:str
+    cursor: str
 
-class Album():
 
-    def __init__(self,info,req):
+class Album:
+    def __init__(self, info, req):
         self.info = info
-        self.req:Requests = req
+        self.req: Requests = req
 
-    '''
+    """
     API: https://photo.baidu.com/youai/album/v1/listfile
     Method: POST
     Param: {
@@ -113,24 +113,26 @@ class Album():
             'has_more': 1,
             'errno': 0,
             }
-    '''
-    def get_pictures(self,cursor='',need_amount=1,limit=100,password='')->AlbumInfo:
-        params = {
-                'album_id': self.info['album_id'],
-                'need_amount':need_amount,
-                'limit':limit,
-                }
+    """
 
-        if cursor != '':
-            params['cursor'] = cursor
-        if password != '':
-            params['passwd'] = password
+    def get_pictures(
+        self, cursor="", need_amount=1, limit=100, password=""
+    ) -> AlbumInfo:
+        params = {
+            "album_id": self.info["album_id"],
+            "need_amount": need_amount,
+            "limit": limit,
+        }
+
+        if cursor != "":
+            params["cursor"] = cursor
+        if password != "":
+            params["passwd"] = password
 
         pageInfo = self.req.postReqJson(
-                url = 'https://photo.baidu.com/youai/album/v1/listfile',
-                data=params
-                )
-        '''
+            url="https://photo.baidu.com/youai/album/v1/listfile", data=params
+        )
+        """
         URL: https://photo.baidu.com/youai/album/v1/copyfile?clienttype=70
         Method: POST
         Params: {
@@ -153,191 +155,207 @@ class Album():
                 "errno": 0,
                 request_id: 311534367474440450
                 }
-        '''
-        '''
+        """
+        """
         URL: https://photo.baidu.com/youai/file/v2/download?clienttype=70
         Method: GET
         Params: {
                 fsid=522136190789429
                 }
-        '''
+        """
         return {
-                'items': [OnlineIterm(i,self.req) for i in pageInfo['list']],
-                'has_more': pageInfo['has_more'],
-                'cursor': pageInfo['cursor'],
+            "items": [OnlineIterm(i, self.req) for i in pageInfo["list"]],
+            "has_more": pageInfo["has_more"],
+            "cursor": pageInfo["cursor"],
         }
-    def __reget_fsid__(self, pic_info)->AlbumInfo:
+
+    def __reget_fsid__(self, pic_info) -> AlbumInfo:
         params = {
-                'album_id': self.info['album_id'],
-                'uk': self.info['cover_info']['uk'],
-                'tid': pic_info['tid'],
-                'list': "[{\"fsid\":%s}]"%(pic_info['fsid']),
-                }
-        res = self.req.postReqJson(url='https://photo.baidu.com/youai/album/v1/copyfile',
-                data=params)
-        if res['errno'] != 0:
+            "album_id": self.info["album_id"],
+            "uk": self.info["cover_info"]["uk"],
+            "tid": pic_info["tid"],
+            "list": '[{"fsid":%s}]' % (pic_info["fsid"]),
+        }
+        res = self.req.postReqJson(
+            url="https://photo.baidu.com/youai/album/v1/copyfile", data=params
+        )
+        if res["errno"] != 0:
             return pic_info
         logging.debug(res)
-        pic_info['fsid'] = res['list'][0]['fsid']
+        pic_info["fsid"] = res["list"][0]["fsid"]
         return pic_info
 
-    def download_pic(self,item: OnlineIterm, dirpath: str):
+    def download_pic(self, item: OnlineIterm, dirpath: str):
         item.info = self.__reget_fsid__(item.info)
         return item.download(dirpath)
 
-    def append(self,itemObjs):
+    def append(self, itemObjs):
         if type(itemObjs) is not list:
             itemObjlist = [itemObjs]
         else:
             itemObjlist = itemObjs
 
-        url = 'https://photo.baidu.com/youai/album/v1/addfile'
-        params = dict( (
-            ('clienttype', '70'),
-            # ('bdstoken', '26.....'),
-            ('album_id', self.info['album_id']),
-            ('tid', self.info['tid']),
-            ('list', '[{}]'.format(",".join( ['''{{"fsid":{}}}'''.format(item.info['fsid']) for item in itemObjlist] ) )),
-        ))
-        logging.debug('Album-append, getParams=[{}]'.format(params))
-        response = self.req.getReqJson(url,params=params)
+        url = "https://photo.baidu.com/youai/album/v1/addfile"
+        params = dict(
+            (
+                ("clienttype", "70"),
+                # ('bdstoken', '26.....'),
+                ("album_id", self.info["album_id"]),
+                ("tid", self.info["tid"]),
+                (
+                    "list",
+                    "[{}]".format(
+                        ",".join(
+                            [
+                                """{{"fsid":{}}}""".format(item.info["fsid"])
+                                for item in itemObjlist
+                            ]
+                        )
+                    ),
+                ),
+            )
+        )
+        logging.debug("Album-append, getParams=[{}]".format(params))
+        response = self.req.getReqJson(url, params=params)
         return response
 
 
+class API:
+    def __init__(self, cookies, proxies={}):
+        self.req = Requests(cookies=cookies, proxies=proxies)
 
+    #     def get(self,method,params):
+    #         urlPrefix = 'https://photo.baidu.com/youai/file/v1/'
+    #         data = self.req.getReqJson(url = urlPrefix+method.strip(), params=params)
+    #         return data
 
-
-
-
-
-
-class API():
-
-    def __init__(self,cookies,proxies={}):
-        self.req = Requests(cookies=cookies,proxies=proxies)
-
-
-#     def get(self,method,params):
-#         urlPrefix = 'https://photo.baidu.com/youai/file/v1/'
-#         data = self.req.getReqJson(url = urlPrefix+method.strip(), params=params)
-#         return data
-
-    def get_SinglePage(self,cursor=None) -> dict:
+    def get_SinglePage(self, cursor=None) -> dict:
         # info of one page.   contains a list of photon info
-        params={
-            'clienttype':70,
-        #     'bdstoken':'ba0b17594ad...這有啥用？',
-        #     'need_thumbnail':1,
-            'need_filter_hidden':0,
-            }
+        params = {
+            "clienttype": 70,
+            #     'bdstoken':'ba0b17594ad...這有啥用？',
+            #     'need_thumbnail':1,
+            "need_filter_hidden": 0,
+        }
         if cursor is not None:
-            params['cursor'] = cursor
-        pageInfo = self.req.getReqJson(url='https://photo.baidu.com/youai/file/v1/list',params=params)
+            params["cursor"] = cursor
+        pageInfo = self.req.getReqJson(
+            url="https://photo.baidu.com/youai/file/v1/list", params=params
+        )
         return {
-            'items'    : [ OnlineIterm(i,self.req) for i in pageInfo['list']] ,
-            'has_more' : pageInfo['has_more'] == 1,
-            'cursor':  pageInfo['cursor'],
+            "items": [OnlineIterm(i, self.req) for i in pageInfo["list"]],
+            "has_more": pageInfo["has_more"] == 1,
+            "cursor": pageInfo["cursor"],
         }
 
-
-    def getAlbumList(self,limit=30):
-        url = 'https://photo.baidu.com/youai/album/v1/list'
-        params = dict( (
-            ('clienttype', '70'),
-            # ('bdstoken', '263...'),
-            ('limit', limit),
-            ('need_amount', '1'),
-            ('need_member', '1'),
-            ('field', 'mtime'),
-        ))
-        pageInfo = self.req.getReqJson(url,params=params)
-        if pageInfo['list'] is None:
+    def getAlbumList(self, limit=30):
+        url = "https://photo.baidu.com/youai/album/v1/list"
+        params = dict(
+            (
+                ("clienttype", "70"),
+                # ('bdstoken', '263...'),
+                ("limit", limit),
+                ("need_amount", "1"),
+                ("need_member", "1"),
+                ("field", "mtime"),
+            )
+        )
+        pageInfo = self.req.getReqJson(url, params=params)
+        if pageInfo["list"] is None:
             return []
         return {
-            'items' : [ Album(i,self.req) for i in pageInfo['list'] ],
-            'has_more' : pageInfo['has_more'] == 1,
-            'cursor':  pageInfo['cursor'],
+            "items": [Album(i, self.req) for i in pageInfo["list"]],
+            "has_more": pageInfo["has_more"] == 1,
+            "cursor": pageInfo["cursor"],
         }
 
-
-
-
-
-    def upload_step1_preCreate(self,fileFull):
+    def upload_step1_preCreate(self, fileFull):
         postdata = {
-          'autoinit': '1',
-          'block_list': '["{}"]'.format(fileFull['md5']),
-          'isdir': '0',
-          'rtype': '1',
-          'ctype': '11', # required
-          'path': '/'+fileFull['fileName'], # required
-          'size': fileFull['size'],# required
-        #   'slice-md5': '4fe8d73cf1ee838b...',
-          'content-md5': fileFull['md5'], # required
-          'local_ctime': fileFull['ctime'],
-          'local_mtime': fileFull['mtime'],
-        #   'media_info': 'QD1xoOXfdIsFhss...'
+            "autoinit": "1",
+            "block_list": '["{}"]'.format(fileFull["md5"]),
+            "isdir": "0",
+            "rtype": "1",
+            "ctype": "11",  # required
+            "path": "/" + fileFull["fileName"],  # required
+            "size": fileFull["size"],  # required
+            #   'slice-md5': '4fe8d73cf1ee838b...',
+            "content-md5": fileFull["md5"],  # required
+            "local_ctime": fileFull["ctime"],
+            "local_mtime": fileFull["mtime"],
+            #   'media_info': 'QD1xoOXfdIsFhss...'
         }
         params = {
-            'clienttype': '70',
-#             'bdstoken': self.req.bdstoken, # requird
+            "clienttype": "70",
+            #             'bdstoken': self.req.bdstoken, # requird
         }
-        logging.debug('upload_step1,postData={}'.format(postdata))
-        data = self.req.postReqJson(url = 'https://photo.baidu.com/youai/file/v1/precreate',params =params,data=postdata )
+        logging.debug("upload_step1,postData={}".format(postdata))
+        data = self.req.postReqJson(
+            url="https://photo.baidu.com/youai/file/v1/precreate",
+            params=params,
+            data=postdata,
+        )
         return data
 
-#         exist: {'data': {'fs_id': 9630...305088, 'size': 14...74, 'md5': '0379955f9bd...002f773217b', 'server_filename': 'Screen.png', 'path': '/youa/web/Screen.png', 'ctime': 16470..., 'mtime': 16470..., 'isdir': 0, 'category': 3, 'server_md5': '9af01bd...7bebeded', 'shoot_time': 1647...309}, 'return_type': 3, 'errno': 0, 'request_id': 48666...003049}
-#         New: {'return_type': 1, 'path': '/youa/web/Screen.png', 'uploadid': 'N1-MTAuNj...DA2MzY3OTQx', 'block_list': [0], 'errno': 0, 'request_id': 48669...67941}
+    #         exist: {'data': {'fs_id': 9630...305088, 'size': 14...74, 'md5': '0379955f9bd...002f773217b', 'server_filename': 'Screen.png', 'path': '/youa/web/Screen.png', 'ctime': 16470..., 'mtime': 16470..., 'isdir': 0, 'category': 3, 'server_md5': '9af01bd...7bebeded', 'shoot_time': 1647...309}, 'return_type': 3, 'errno': 0, 'request_id': 48666...003049}
+    #         New: {'return_type': 1, 'path': '/youa/web/Screen.png', 'uploadid': 'N1-MTAuNj...DA2MzY3OTQx', 'block_list': [0], 'errno': 0, 'request_id': 48669...67941}
 
-
-    def upload_step2_superfile2(self,preCreateInfo,fileFull):
-        params = dict((
-            ('method', 'upload'),
-            ('app_id', '16051585'),
-            ('channel', 'chunlei'),
-            ('clienttype', '70'),
-            ('web', '1'),
-#             ('logid', 'MTY.........'), # ? , changed every time
-            ('path', '/'+fileFull['fileName']),
-            ('uploadid', preCreateInfo['uploadid']),
-            ('partseq', '0'),
-        ))
+    def upload_step2_superfile2(self, preCreateInfo, fileFull):
+        params = dict(
+            (
+                ("method", "upload"),
+                ("app_id", "16051585"),
+                ("channel", "chunlei"),
+                ("clienttype", "70"),
+                ("web", "1"),
+                #             ('logid', 'MTY.........'), # ? , changed every time
+                ("path", "/" + fileFull["fileName"]),
+                ("uploadid", preCreateInfo["uploadid"]),
+                ("partseq", "0"),
+            )
+        )
         # with open(filePath, 'rb') as f:
-            # response = self.req.post('https://c3.pcs.baidu.com/rest/2.0/pcs/superfile2', params=params, files={fileName: f} )
-        logging.debug('upload_step2,postParams={}'.format(params))
-        response = self.req.post('https://c3.pcs.baidu.com/rest/2.0/pcs/superfile2', params=params, files={fileFull['fileName']: io.BytesIO(fileFull['bin']) } )
+        # response = self.req.post('https://c3.pcs.baidu.com/rest/2.0/pcs/superfile2', params=params, files={fileName: f} )
+        logging.debug("upload_step2,postParams={}".format(params))
+        response = self.req.post(
+            "https://c3.pcs.baidu.com/rest/2.0/pcs/superfile2",
+            params=params,
+            files={fileFull["fileName"]: io.BytesIO(fileFull["bin"])},
+        )
         return response.json()
 
-    def upload_step3_create(self,preCreateInfo,fileFull):
-        params = dict((
-            ('clienttype', '70'),
-#             ('bdstoken', self.req.bdstoken),
-        ))
+    def upload_step3_create(self, preCreateInfo, fileFull):
+        params = dict(
+            (
+                ("clienttype", "70"),
+                #             ('bdstoken', self.req.bdstoken),
+            )
+        )
 
         data = {
-          'path': '/'+fileFull['fileName'],
-          'size': fileFull['size'],
-          'uploadid': preCreateInfo['uploadid'],
-          'block_list': '["{}"]'.format(fileFull['md5']),
-          'isdir': '0',
-          'rtype': '1',
-          'content-md5': fileFull['md5'],
-          'ctype': '11',
-#           'media_info': 'QD1xoOX.....'
+            "path": "/" + fileFull["fileName"],
+            "size": fileFull["size"],
+            "uploadid": preCreateInfo["uploadid"],
+            "block_list": '["{}"]'.format(fileFull["md5"]),
+            "isdir": "0",
+            "rtype": "1",
+            "content-md5": fileFull["md5"],
+            "ctype": "11",
+            #           'media_info': 'QD1xoOX.....'
         }
-        logging.debug('upload_step3,postData={}'.format(data))
-        return self.req.post('https://photo.baidu.com/youai/file/v1/create', params=params, data=data).json()
+        logging.debug("upload_step3,postData={}".format(data))
+        return self.req.post(
+            "https://photo.baidu.com/youai/file/v1/create", params=params, data=data
+        ).json()
 
-
-    def upload_1file(self,filePath):
+    def upload_1file(self, filePath):
         # get_file_fullContent,fileName,localFilePath,size,ctime,mtime,md5,bin
         fobj = get_file_fullContent(filePath)
         preC = self.upload_step1_preCreate(fobj)
-        if preC.get('uploadid',None) is not None:
-            reqJson1 = self.upload_step2_superfile2(preCreateInfo=preC,fileFull=fobj)
-            reqJson2 = self.upload_step3_create(preCreateInfo=preC,fileFull=fobj)
-            return preC,reqJson1,reqJson2
+        if preC.get("uploadid", None) is not None:
+            reqJson1 = self.upload_step2_superfile2(preCreateInfo=preC, fileFull=fobj)
+            reqJson2 = self.upload_step3_create(preCreateInfo=preC, fileFull=fobj)
+            return preC, reqJson1, reqJson2
         else:
             pass
             # file exsis online, 確認網頁操作時也沒有重新上傳
-            return preC,None,None
+            return preC, None, None

--- a/pybaiduphoto/API.py
+++ b/pybaiduphoto/API.py
@@ -66,7 +66,7 @@ class OnlineIterm:
         if isCheckMd5:
             localMd5 = hashlib.md5(req.content).hexdigest()
             if self.info["md5"] != localMd5:
-                info.error("md5 check error, file=[{}]".format(filePath))
+                logging.info.error("md5 check error, file=[{}]".format(filePath))
 
     def delete(self, fdis_list=None):
         url = "https://photo.baidu.com/youai/file/v1/delete"

--- a/pybaiduphoto/API.py
+++ b/pybaiduphoto/API.py
@@ -157,10 +157,6 @@ class Album:
 
         return pic_info
 
-    def download_pic(self, item: OnlineIterm, dirpath: str):
-        item.info = self.__reget_fsid__(item.info)
-        return item.download(dirpath)
-
     def append(self, itemObjs):
         if type(itemObjs) is not list:
             itemObjlist = [itemObjs]

--- a/pybaiduphoto/API.py
+++ b/pybaiduphoto/API.py
@@ -7,6 +7,8 @@ from .Requests import Requests
 
 from typing import List, TypedDict, Any
 
+logger = logging.getLogger(__name__)
+
 # def get_md5_by_binString(binString):
 #     return hashlib.md5(binString).hexdigest()
 #
@@ -81,7 +83,7 @@ class OnlineIterm:
         if isCheckMd5:
             localMd5 = hashlib.md5(req.content).hexdigest()
             if self.info["md5"] != localMd5:
-                logging.info.error("md5 check error, file=[{}]".format(filePath))
+                logger.info.error("md5 check error, file=[{}]".format(filePath))
 
     def delete(self, fdis_list=None):
         url = "https://photo.baidu.com/youai/file/v1/delete"
@@ -91,7 +93,7 @@ class OnlineIterm:
             "clienttype": "70",
             "fsid_list": "[{}]".format(",".join(fdis_list)),
         }
-        logging.debug("item-delete:get params=[{}]".format(params))
+        logger.debug("item-delete:get params=[{}]".format(params))
         r = self.req.getReqJson(url, params=params)
         return r
 
@@ -151,7 +153,7 @@ class Album:
         if res["errno"] != 0:
             return pic_info
 
-        logging.debug(res)
+        logger.debug(res)
 
         pic_info["fsid"] = res["list"][0]["fsid"]
 
@@ -183,7 +185,7 @@ class Album:
                 ),
             )
         )
-        logging.debug("Album-append, getParams=[{}]".format(params))
+        logger.debug("Album-append, getParams=[{}]".format(params))
         response = self.req.getReqJson(url, params=params)
         return response
 
@@ -256,7 +258,7 @@ class API:
             "clienttype": "70",
             #             'bdstoken': self.req.bdstoken, # requird
         }
-        logging.debug("upload_step1,postData={}".format(postdata))
+        logger.debug("upload_step1,postData={}".format(postdata))
         data = self.req.postReqJson(
             url="https://photo.baidu.com/youai/file/v1/precreate",
             params=params,
@@ -283,7 +285,7 @@ class API:
         )
         # with open(filePath, 'rb') as f:
         # response = self.req.post('https://c3.pcs.baidu.com/rest/2.0/pcs/superfile2', params=params, files={fileName: f} )
-        logging.debug("upload_step2,postParams={}".format(params))
+        logger.debug("upload_step2,postParams={}".format(params))
         response = self.req.post(
             "https://c3.pcs.baidu.com/rest/2.0/pcs/superfile2",
             params=params,
@@ -310,7 +312,7 @@ class API:
             "ctype": "11",
             #           'media_info': 'QD1xoOX.....'
         }
-        logging.debug("upload_step3,postData={}".format(data))
+        logger.debug("upload_step3,postData={}".format(data))
         return self.req.post(
             "https://photo.baidu.com/youai/file/v1/create", params=params, data=data
         ).json()

--- a/pybaiduphoto/Requests.py
+++ b/pybaiduphoto/Requests.py
@@ -1,6 +1,8 @@
 import requests
 import logging
 
+logger = logging.getLogger(__name__)
+
 
 class Requests:
     def __init__(self, cookies, proxies=None):
@@ -44,7 +46,7 @@ class Requests:
                 d = l
                 break
         if d is None:
-            logging.error("can not get bdstoken")
+            logger.error("can not get bdstoken")
             return
         return (
             l.split("=")[1]
@@ -93,7 +95,7 @@ class Requests:
         if data["errno"] == 0:
             return data
         else:
-            logging.error("request return error, return = {}".format(data))
+            logger.error("request return error, return = {}".format(data))
             return data
         return
 
@@ -102,6 +104,6 @@ class Requests:
         if data["errno"] == 0:
             return data
         else:
-            logging.error("request return error, return = {}".format(data))
+            logger.error("request return error, return = {}".format(data))
             return data
         return

--- a/pybaiduphoto/Requests.py
+++ b/pybaiduphoto/Requests.py
@@ -1,33 +1,29 @@
-
 import requests
 import logging
 
 
-
-class Requests():
-
-    def __init__(self,cookies,proxies=None):
+class Requests:
+    def __init__(self, cookies, proxies=None):
         self.cookies = cookies
 
         self.headers = {
-            'Connection': 'keep-alive',
-            'sec-ch-ua': '" Not A;Brand";v="99", "Chromium";v="99", "Google Chrome";v="99"',
-            'Accept': 'application/json, text/plain, */*',
-            'X-Requested-With': 'XMLHttpRequest',
-            'sec-ch-ua-mobile': '?0',
-            'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.51 Safari/537.36',
-            'sec-ch-ua-platform': '"macOS"',
-            'Sec-Fetch-Site': 'same-origin',
-            'Sec-Fetch-Mode': 'cors',
-            'Sec-Fetch-Dest': 'empty',
-            'Referer': 'https://photo.baidu.com/photo/web/home',
-            'Accept-Language': 'zh-CN,zh;q=0.9,zh-TW;q=0.8,en;q=0.7',
+            "Connection": "keep-alive",
+            "sec-ch-ua": '" Not A;Brand";v="99", "Chromium";v="99", "Google Chrome";v="99"',
+            "Accept": "application/json, text/plain, */*",
+            "X-Requested-With": "XMLHttpRequest",
+            "sec-ch-ua-mobile": "?0",
+            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.51 Safari/537.36",
+            "sec-ch-ua-platform": '"macOS"',
+            "Sec-Fetch-Site": "same-origin",
+            "Sec-Fetch-Mode": "cors",
+            "Sec-Fetch-Dest": "empty",
+            "Referer": "https://photo.baidu.com/photo/web/home",
+            "Accept-Language": "zh-CN,zh;q=0.9,zh-TW;q=0.8,en;q=0.7",
         }
 
         self.proxies = proxies
         #
         self.bdstoken = None
-
 
     def get_proxies(self):
         if self.proxies is None:
@@ -37,58 +33,75 @@ class Requests():
         # print(type(r),r)
         return r
 
-
-
     def get_bdstoken(self):
-        url = 'https://photo.baidu.com/photo/web/home'
-        response = requests.get(url,proxies=self.get_proxies(),cookies=self.cookies,headers=self.headers)
+        url = "https://photo.baidu.com/photo/web/home"
+        response = requests.get(
+            url, proxies=self.get_proxies(), cookies=self.cookies, headers=self.headers
+        )
         d = None
-        for l in response.text.split('\n'):
-            if 'templateData' in l:
+        for l in response.text.split("\n"):
+            if "templateData" in l:
                 d = l
                 break
         if d is None:
-            logging.error('can not get bdstoken')
+            logging.error("can not get bdstoken")
             return
-        return l.split('=')[1].split(';')[0].split(',')[0].split(':')[1].replace("'","").strip()
-
+        return (
+            l.split("=")[1]
+            .split(";")[0]
+            .split(",")[0]
+            .split(":")[1]
+            .replace("'", "")
+            .strip()
+        )
 
     def get_bdstoken_Cache(self):
         if self.bdstoken is None:
             self.bdstoken = self.get_bdstoken()
         return self.bdstoken
 
-    def get(self,url,**kwargs):
-        if 'params' in kwargs:
-            kwargs['params']['bdstoken'] = self.get_bdstoken_Cache()
+    def get(self, url, **kwargs):
+        if "params" in kwargs:
+            kwargs["params"]["bdstoken"] = self.get_bdstoken_Cache()
         else:
-            kwargs['params'] = {'bdstoken':self.get_bdstoken_Cache()}
-        req = requests.get(url=url,proxies=self.get_proxies(),cookies=self.cookies,headers=self.headers,**kwargs)
+            kwargs["params"] = {"bdstoken": self.get_bdstoken_Cache()}
+        req = requests.get(
+            url=url,
+            proxies=self.get_proxies(),
+            cookies=self.cookies,
+            headers=self.headers,
+            **kwargs
+        )
         return req
 
-    def post(self,url,**kwargs):
-        if 'params' in kwargs:
-            kwargs['params']['bdstoken'] = self.get_bdstoken_Cache()
+    def post(self, url, **kwargs):
+        if "params" in kwargs:
+            kwargs["params"]["bdstoken"] = self.get_bdstoken_Cache()
         else:
-            kwargs['params'] = {'bdstoken':self.get_bdstoken_Cache()}
-        req = requests.post(url=url,proxies=self.get_proxies(),cookies=self.cookies,headers=self.headers,**kwargs)
+            kwargs["params"] = {"bdstoken": self.get_bdstoken_Cache()}
+        req = requests.post(
+            url=url,
+            proxies=self.get_proxies(),
+            cookies=self.cookies,
+            headers=self.headers,
+            **kwargs
+        )
         return req
 
-
-    def getReqJson(self,url,**kwargs):
-        data = self.get(url,**kwargs).json()
-        if data['errno'] == 0:
+    def getReqJson(self, url, **kwargs):
+        data = self.get(url, **kwargs).json()
+        if data["errno"] == 0:
             return data
         else:
-            logging.error('request return error, return = {}'.format(data))
+            logging.error("request return error, return = {}".format(data))
             return data
         return
 
-    def postReqJson(self,url,**kwargs):
-        data = self.post(url,**kwargs).json()
-        if data['errno'] == 0:
+    def postReqJson(self, url, **kwargs):
+        data = self.post(url, **kwargs).json()
+        if data["errno"] == 0:
             return data
         else:
-            logging.error('request return error, return = {}'.format(data))
+            logging.error("request return error, return = {}".format(data))
             return data
         return

--- a/pybaiduphoto/utils.py
+++ b/pybaiduphoto/utils.py
@@ -1,0 +1,82 @@
+from .API import Album
+import asyncio
+import os
+import logging
+import threading
+
+logger = logging.getLogger(__name__)
+
+
+def download(item, download_path: str):
+    try:
+        file_path = os.path.join(download_path, os.path.basename(item.info["path"]))
+        logger.info("下载 {} 到 {}".format(item.info["path"], download_path))
+        if os.path.exists(file_path):
+            logger.debug("文件 {} 已经存在，跳过".format(file_path))
+            return
+
+        item.download(DirPath=download_path)
+    except Exception as e:
+        logger.error(e)
+
+
+def download_album(album: Album, download_path: str):
+    """
+    默认情况下 download_album 启用了对协程池的支持。并且只开启了两个协程，这是因为协程开启过多会导致 HTTP 请求失败。
+    如果需要设置其它数量的协程，请在第一次调用此函数前调用 CoroutinePool.get_default(n)
+    """
+    album_info = album.get_pictures()
+    pool = CoroutinePool.get_default(2)
+
+    while True:
+        for pic in album_info["items"]:
+            pool.add(download, pic, download_path)
+
+        if not album_info["has_more"]:
+            break
+
+        album_info = album.get_pictures(cursor=album_info["cursor"])
+
+
+class CoroutinePool:
+    """
+    协程池
+
+    协程池可以将函数添加到池中运行。协程池在析构时会自动等待所有任务结束
+    """
+
+    __default = None
+
+    @classmethod
+    def get_default(cls, value: int = 10):
+        """
+        获取一个默认的协程池
+
+        :param value: 开启的协程数量。此参数只在第一次调用此函数时有效
+        """
+        if cls.__default is None:
+            cls.__default = CoroutinePool(value=value)
+        return cls.__default
+
+    def __init__(self, value: int = 10) -> None:
+        self.__sem = threading.Semaphore(value)
+        self.__tasks = []
+        self.__loop = asyncio.new_event_loop()
+
+    def add(self, func, *args):
+        def wrap():
+            with self.__sem:
+                func(*args)
+
+        self.__tasks.append(self.__loop.run_in_executor(None, wrap))
+
+    def wait(self):
+        """
+        等待协程池中的任务结束
+        """
+        self.__loop.run_until_complete(asyncio.wait(self.__tasks))
+        self.__tasks = []
+
+    def __del__(self):
+        self.wait()
+        self.__loop.close()

--- a/upload.py
+++ b/upload.py
@@ -1,27 +1,24 @@
 #!/usr/bin/env python3
-import sys,os,datetime
+import sys, os, datetime
 
 
-#--------------
-name    = 'pybaiduphoto'
+# --------------
+name = "pybaiduphoto"
 scripts = []
 description = "A simple API to interact with baidu-photo"
-#--------------
+# --------------
 
 
-
-
-python   = sys.executable
+python = sys.executable
 filepath = os.path.realpath(__file__)
 projpath = os.path.dirname(filepath)
-dist = os.path.join(projpath,'dist')
-passDir = os.path.join(os.environ['HOME'],'Dropbox/AutoPassword')
+dist = os.path.join(projpath, "dist")
+passDir = os.path.join(os.environ["HOME"], "Dropbox/AutoPassword")
 sys.path.insert(0, passDir)
 import password as pw
 
 
-
-setupcontext = '''
+setupcontext = """
 import setuptools
 #from setuptools import setup
 
@@ -40,26 +37,28 @@ setuptools.setup(
     python_requires='>=3.6',
     url = "https://github.com/HengyueLi/baiduphoto",
 )
-'''.format(name    = name ,
-           scripts = str(scripts),
-           version = datetime.datetime.now().strftime("%Y.%m.%d.%H%M") ,
-           description = description,
-           install_requires = [ i for i in open('requirements.txt').read().split('\n') if len(i)>1  ] )
+""".format(
+    name=name,
+    scripts=str(scripts),
+    version=datetime.datetime.now().strftime("%Y.%m.%d.%H%M"),
+    description=description,
+    install_requires=[
+        i for i in open("requirements.txt").read().split("\n") if len(i) > 1
+    ],
+)
 
 
-
-
-
-os.system('rm -rf {}/*'.format(dist))
-os.system('rm -rf setup.py')
-with open('setup.py','w') as f:
+os.system("rm -rf {}/*".format(dist))
+os.system("rm -rf setup.py")
+with open("setup.py", "w") as f:
     f.write(setupcontext)
-os.system('{} setup.py sdist'.format(python))
-#---------------------------------------
+os.system("{} setup.py sdist".format(python))
+# ---------------------------------------
 # upload with username&password
 command = "twine upload dist/* -u {username} -p {password}".format(
-                username = pw.GetAutoPasswd('pip','username').get(),
-                password = pw.GetAutoPasswd('pip','password').get() )
+    username=pw.GetAutoPasswd("pip", "username").get(),
+    password=pw.GetAutoPasswd("pip", "password").get(),
+)
 os.system(command)
-#---------------------------------------
-os.system('rm -rf dist setup.py *egg-info*')
+# ---------------------------------------
+os.system("rm -rf dist setup.py *egg-info*")


### PR DESCRIPTION
- refactor(*): 添加了 pre-commit 来格式化代码
- feat(gitignore): 忽略 python 缓存文件
- fix(API): 修复了日志打印问题
- refactor(API): 删除了一些不重要的注释，局部格式化了代码
- feat(API): 延迟计算 OnlineIterm 的 info 属性。以便与普通图片的下载相统一
- feat(API): 删除 album::download_pic 方法

如上所示，主要做了以下更改：

1. 添加了 [pre-commit](https://pre-commit.com/) 来格式化代码。格式风格选用了 black。以后每次 commit
   代码都会强制进行代码格式化
2. 修复了日志打印问题。这个 bug 看起来是少打了 logging 导致的
3. 延迟计算了 OnlineIterm 的 info 属性。这样 album 的下载方式都和以前的方法统一了
