### PR TITLE
fix: 修复下载他人分享文件时的 50504 错误

### DIFF
--- a/pybaiduphoto/OnlineItem.py
+++ b/pybaiduphoto/OnlineItem.py
@@ -53,7 +53,7 @@ class OnlineItem(apiObject):
         if isCheckMd5:
             localMd5 = hashlib.md5(fileContent).hexdigest()
             if self.info["md5"] != localMd5:
-                info.error("md5 check error, file=[{}]".format(filePath))
+                print("MD5 check error, file=[{}]".format(filePath))  # 简单打印错误
 
     def delete(self, fdis_list=None):
         url = "https://photo.baidu.com/youai/file/v1/delete"


### PR DESCRIPTION
## 问题描述
当下载他人分享到相册的文件时，`getReqJson()` 返回 `errno: 50504` 错误，导致下载失败。

## 修复方案
直接使用 `info['dlink']` 替代 `getReqJson()`，因为该字段在 `info` 中已缓存且有效。